### PR TITLE
Handle missing sound index in Tarnish packer

### DIFF
--- a/packing/src/main/kotlin/org/jire/swiftfup/packing/TarnishPacker.kt
+++ b/packing/src/main/kotlin/org/jire/swiftfup/packing/TarnishPacker.kt
@@ -33,11 +33,6 @@ object TarnishPacker {
         val cacheTo = CacheLibrary.create(cachePath)
 
         if (SOUNDS) {
-            if (true) {
-                println(cacheTo.data(SOUNDS_INDEX, 2720)!!.size)
-                return
-            }
-
             sounds(cachePath, cacheTo)
 
             cacheTo.update()
@@ -117,19 +112,12 @@ object TarnishPacker {
     private const val SOUNDS_INDEX = 6
 
     private fun sounds(cachePath: String, cacheTo: CacheLibrary) {
-        if (false) {
-            cacheTo.createIndex()
-            /*val index = cacheTo.index(SOUNDS_INDEX)
-            index.cache()
-            for (archive in index.archives()) {
-                cacheTo.remove(SOUNDS_INDEX, archive.id)
-                println("removed archive ${archive.id}")
-            }
-            index.update()*/
-            return
+        val index = if (cacheTo.exists(SOUNDS_INDEX)) {
+            cacheTo.index(SOUNDS_INDEX)
+        } else {
+            cacheTo.createIndex().also { cacheTo.reload() }
         }
-
-        val index = cacheTo.index(SOUNDS_INDEX)
+        val indexId = index.id
 
         val indexBuf = Unpooled.buffer()
         indexBuf.writeShort(0)
@@ -142,7 +130,7 @@ object TarnishPacker {
             val data = soundFile.readBytes()
 
             indexBuf.writeShort(id)
-            cacheTo.put(SOUNDS_INDEX, id, data)
+            cacheTo.put(indexId, id, data)
             amount++
         }
 


### PR DESCRIPTION
## Summary
- remove the temporary debug guard that short-circuited Tarnish sound packing
- initialize the sound index when absent and write archives against the resolved index id

## Testing
- `./gradlew :packing:compileKotlin` *(fails: toolchain java 11 not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ce4ebe0328832e8588c85327dfec8d